### PR TITLE
feat: infer latest specified compat date as default

### DIFF
--- a/src/date.ts
+++ b/src/date.ts
@@ -9,11 +9,17 @@ export function resolveCompatibilityDates(
 ): CompatibilityDates {
   // Initialize with defaults object
   const dates = {
-    ...(typeof defaults === "string" ? { default: defaults } : defaults),
+    default: "",
   } as CompatibilityDates;
 
-  // Normalize default date
-  dates.default = formatDate(dates.default || "");
+  // Add normalized defaults
+  const _defaults =
+    typeof defaults === "string" ? { default: defaults } : defaults || {};
+  for (const [key, value] of Object.entries(_defaults)) {
+    if (value) {
+      dates[key as PlatformName] = formatDate(value);
+    }
+  }
 
   // Add normalized input values
   const _input = typeof input === "string" ? { default: input } : input || {};
@@ -22,6 +28,10 @@ export function resolveCompatibilityDates(
       dates[key as PlatformName] = formatDate(value);
     }
   }
+
+  // Normalize default date
+  dates.default =
+    formatDate(dates.default || "") || Object.values(dates).sort().pop() || "";
 
   return dates;
 }

--- a/test/date.test.ts
+++ b/test/date.test.ts
@@ -36,6 +36,15 @@ describe("date utils", () => {
         expected: { cloudflare: "2022-01-01", default: "2021-01-01" },
       },
       {
+        input: { cloudflare: "2022-01-01", vercel: "2022-01-02" },
+        defaults: "",
+        expected: {
+          cloudflare: "2022-01-01",
+          vercel: "2022-01-02",
+          default: "2022-01-02",
+        },
+      },
+      {
         input: "2021-01-x",
         defaults: undefined,
         expected: { default: "" },


### PR DESCRIPTION
When users specifies an object `{ cloudflare: "2022-01-01", vercel: "2022-01-02" }`, we infer `default` key based on latest specified user date as fallback.

**Note:** It is not ideal, but i found it a good DX compromise when we added object syntax complexity..